### PR TITLE
Update fmt dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 
 /build/
 /subprojects/fmt-5.3.0/
+/subprojects/fmt-7.1.3/
 /subprojects/googletest-release-1.8.1/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # .gitignore
 
+/.clangd/
 /build/
+/compile_commands.json
 /subprojects/fmt-5.3.0/
 /subprojects/fmt-7.1.3/
 /subprojects/googletest-release-1.8.1/
+/subprojects/packagecache/

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = fmt-5.3.0
+directory = fmt-7.1.3
 
-source_url = https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz
-source_filename = fmt-5.3.0.tar.gz
-source_hash = defa24a9af4c622a7134076602070b45721a43c51598c8456ec6f2c4dbb51c89
+source_url = https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz
+source_filename = fmt-7.1.3.tar.gz
+source_hash = 5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/fmt/5.3.0/1/get_zip
-patch_filename = fmt-5.3.0-1-wrap.zip
-patch_hash = 18f21a3b8833949c35d4ac88a7059577d5fa24b98786e4b1b2d3d81bb811440f
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_7.1.3-1/get_patch
+patch_filename = fmt-7.1.3-1-wrap.zip
+patch_hash = 6eb951a51806fd6ffd596064825c39b844c1fe1799840ef507b61a53dba08213


### PR DESCRIPTION
The old format was having an issue with GCC 9.x.

Going from 5.3.0 to 7.1.3.